### PR TITLE
naive addition of OIDC step

### DIFF
--- a/actions/tests/terratest/action.yml
+++ b/actions/tests/terratest/action.yml
@@ -59,6 +59,14 @@ runs:
         base-ref: ${{ inputs.base-ref }}
         labels: ${{ inputs.labels }}
 
+    # https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: ${{ env.AWS_REGION }}
+        role-to-assume: ${{ env.IAM_ROLE_ARN }}
+        role-session-name: ${{ env.IAM_ROLE_SESSION_NAME }}
+
     - name: "Inject secrets"
       shell: bash
       run: |


### PR DESCRIPTION
## what
* Enabling secret access for this action via CloudPosse's OIDC store.
* If the necessary paramters for access the OIDC store aren't found, secret values will default to those passed in with the workflow.

## why
* This allows this action to work in all Cloud Posse repos without us hardcoding secrets org-wide, which presents an exfiltration risk if any one of our repos has poorly-configured GitHub Actions.

## references
* DEV-116